### PR TITLE
Adding defun macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ It provides both a compiler and a interpreter that can be used as scripting lang
 
 (quickload :trivial-http)
 (princ-to-string (with-cl '(trivial-http:http-get "http://lite.duckduckgo.com/lite/")))
+
+(defun fac2 [n]
+  (reduce (function *) (loop for i from 1 to n collect i)))
+
+(fac2 (fac2 3))
 ```
 Also check the project tasks.
 

--- a/README.md
+++ b/README.md
@@ -52,10 +52,15 @@ It provides both a compiler and a interpreter that can be used as scripting lang
 (quickload :trivial-http)
 (princ-to-string (with-cl '(trivial-http:http-get "http://lite.duckduckgo.com/lite/")))
 
-(defun fac2 [n]
+(defun fac2 (n)
   (reduce (function *) (loop for i from 1 to n collect i)))
 
-(fac2 (fac2 3))
+(fac2 (fac2 (cl-int 3)))
+
+(defun discriminant (a b c)
+  (- (* b b) (* 4 a c)))
+
+(discriminant (cl-int 1) (cl-int 2) (cl-int 3))
 ```
 Also check the project tasks.
 

--- a/src/abclj/core.clj
+++ b/src/abclj/core.clj
@@ -468,12 +468,10 @@
 (defmacro defun
   "Defines a new function named `sym` in the global environment."
   [sym args body]
-  `(let [fn-name# (symbol (str "abcl-" ~sym))
-         cl-symb# (cl-evaluate
+  `(let [cl-symb# (cl-evaluate
                    (str (seq (into []
                                    (declojurify
-                                    '(defun fn-name# (~@args) ~body))))))]
-     (defn ~sym ~args
-       (let [cl-objs# (map clj->cl ~args)]
-         (cl->clj
-          (apply #(funcall (.getSymbolFunctionOrDie cl-symb#) %) cl-objs#))))))
+                                    '(defun abclj-fn# ~args ~body))))))]
+     (defn ~sym [~@args]
+       (cl->clj
+        (funcall (.getSymbolFunctionOrDie cl-symb#) ~@args)))))

--- a/src/abclj/core.clj
+++ b/src/abclj/core.clj
@@ -465,3 +465,15 @@
     {:pre [(is (cl-obj? obj)) (is (symbol? s))]}
     (funcall cl-coerce obj (cl-symbol s))))
 
+(defmacro defun
+  "Defines a new function named `sym` in the global environment."
+  [sym args body]
+  `(let [fn-name# (symbol (str "abcl-" ~sym))
+         cl-symb# (cl-evaluate
+                   (str (seq (into []
+                                   (declojurify
+                                    '(defun fn-name# (~@args) ~body))))))]
+     (defn ~sym ~args
+       (let [cl-objs# (map clj->cl ~args)]
+         (cl->clj
+          (apply #(funcall (.getSymbolFunctionOrDie cl-symb#) %) cl-objs#))))))


### PR DESCRIPTION
I changed the default syntax to be more lispy using parenthesis to define the arguments of the function

```clojure
(defun discriminant (a b c)
  (- (* b b) (* 4 a c)))

(discriminant (cl-int 1) (cl-int 2) (cl-int 3))
```

There is a TODO here, the arguments can be replaced by core clojure values if we implement an `cl-apply` to be used inside defun.