### PR TITLE
Fixes/improvements in defun

### DIFF
--- a/src/abclj/core.clj
+++ b/src/abclj/core.clj
@@ -476,12 +476,9 @@
                                     '(defun abclj-fn# ~args ~@body))))))]
      (defn ~sym [~@args]
        (let [cl-objs# (map clj->cl (list ~@args))
-             cl-objs# (cond
-                        (= (count cl-objs#) 0) cl-nil
-                        (= (count cl-objs#) 1) (cl-cons (conj (vec cl-objs#) cl-nil))
-                        :else
-                        (cl-cons (vec cl-objs#)))
+             cl-objs# (if (= (count cl-objs#) 0)
+                        cl-nil
+                        (cl-cons (conj (vec cl-objs#) cl-nil)))
              apply# (.getSymbolFunctionOrDie (cl-symbol (symbol "cl/apply")))]
          (cl->clj
           (funcall apply# (.getSymbolFunctionOrDie cl-symb#) cl-objs#))))))
-

--- a/src/abclj/core.clj
+++ b/src/abclj/core.clj
@@ -473,7 +473,7 @@
   `(let [cl-symb# (cl-evaluate
                    (str (seq (into []
                                    (declojurify
-                                    '(defun abclj-fn# ~args ~@body))))))]
+                                    '(defun ~sym ~args ~@body))))))]
      (defn ~sym [~@args]
        (let [cl-objs# (map clj->cl (list ~@args))
              cl-objs# (if (= (count cl-objs#) 0)

--- a/test/abclj/core_test.clj
+++ b/test/abclj/core_test.clj
@@ -106,3 +106,20 @@
   (testing
     (is (= 3 (cl->clj (cl-evaluate "(+ 1 2)"))))
     (is (= 3 (cl->clj (cl-evaluate (cl-cons [(cl-symbol 'cl/+) 1 2 cl-nil])))))))
+
+(defun adding (a b)
+  (+ a b))
+
+(defun multiply (a b)
+  (* a b))
+
+(defun blah (a b)
+  (let ((add (adding a b))
+        (mul (multiply a b)))
+    (+ mul add)))
+
+(deftest defun-with-nested-fns
+  (testing
+    (is (= 3 (adding 1 2)))
+    (is (= 2 (multiply 1 2)))
+    (is (= 5 (blah 1 2)))))


### PR DESCRIPTION
You can now call a function defined by `defun` inside another `defun`... which is expected, but the previous usage of gensym did not allowed that to happen.