### PR TITLE
clojurifiable cons to clj lazyseq

### DIFF
--- a/src/abclj/core.clj
+++ b/src/abclj/core.clj
@@ -305,6 +305,8 @@
 (defprotocol CommonLispfiable
   (clj->cl [this]))
 
+(declare cl-cons)
+
 (extend-protocol CommonLispfiable
   Long (clj->cl [obj]
          (cl-int obj))
@@ -328,6 +330,12 @@
               cl-nil))
   nil (clj->cl [_]
         cl-nil)
+  clojure.lang.LazySeq (clj->cl [obj]
+                         (letfn [(add-nil-cdr [v]
+                                   (if (seq? v)
+                                     (conj (vec v) cl-nil)
+                                     v))]
+                           (cl-cons (postwalk add-nil-cdr obj))))
   Object (clj->cl [obj]
            obj))
 

--- a/src/abclj/core.clj
+++ b/src/abclj/core.clj
@@ -464,6 +464,8 @@
              (if (= "KEYWORD" (-> ^Symbol obj ^org.armedbear.lisp.Package (.getPackage) .getName))
                (-> ^Symbol obj .-name str keyword)
                (-> ^Symbol obj .-name str symbol))))
+  Cons (cl->clj [obj]
+         (map cl->clj (cons->vec obj)))
   Object (cl->clj [obj]
            obj))
 

--- a/test/abclj/core_test.clj
+++ b/test/abclj/core_test.clj
@@ -128,3 +128,8 @@
     (is (= 3 (adding 1 2)))
     (is (= 2 (multiply 1 2)))
     (is (= 5 (blah 1 2)))))
+
+(deftest cl-cons->clj
+  (testing
+    (is (= '(2 3 4) (with-cl->clj
+                      '(mapcar (lambda (x) (+ x 1)) '(1 2 3)))))))

--- a/test/abclj/core_test.clj
+++ b/test/abclj/core_test.clj
@@ -133,3 +133,9 @@
   (testing
     (is (= '(2 3 4) (with-cl->clj
                       '(mapcar (lambda (x) (+ x 1)) '(1 2 3)))))))
+
+(deftest clj->cl-cons
+  (testing
+      (is (= (let [cons (clj->cl (map inc [1 2 3]))]
+               (.-car ^Cons cons))
+             (cl-int 2)))))


### PR DESCRIPTION


```clj
(with-cl->clj
   '(mapcar (lambda (x) (+ x 1)) '(1 2 3)))
```

Now returns a clojure lazyseq.